### PR TITLE
#161617377 responsive image

### DIFF
--- a/__tests__/components/atoms/homeLink.spec.js
+++ b/__tests__/components/atoms/homeLink.spec.js
@@ -8,7 +8,7 @@ describe('HomeLink', () => {
   it('should have the correct item', (done) => {
     const wrapper = shallow(<HomeLink />);
 
-    expect(wrapper.find('img').length).toEqual(1);
+    expect(wrapper.find('i').length).toEqual(1);
     done();
   });
 });

--- a/src/components/atoms/HomeLink/index.jsx
+++ b/src/components/atoms/HomeLink/index.jsx
@@ -7,7 +7,7 @@ import style from './style.css';
 
 const HomeLink = () => (
   <Link to="/" className={style.home}>
-    <img className={style.logo} src={logo} alt="Ride My Way logo, home" />
+    <i className={`far fa-registered ${style.logo}`} />
   </Link>
 );
 

--- a/src/components/atoms/HomeLink/style.css
+++ b/src/components/atoms/HomeLink/style.css
@@ -1,6 +1,10 @@
 .logo {
   width: 70px;
   height: 70px;
+  font-size: 70px;
+  color: black;
+  font-weight: lighter;
+  margin-top: 7px;
 }
 
 .home {

--- a/src/components/compounds/AuthModal/style.css
+++ b/src/components/compounds/AuthModal/style.css
@@ -27,6 +27,7 @@
   position: relative;
   margin: 13px;
   left: 90%;
+  color: black;
 }
 
 .close_icon:focus {
@@ -57,10 +58,12 @@
   border-bottom: 2px solid rgb(0, 0, 42);
 }
 
-
-
 @media screen and (min-height: 470px) {
   .modal {
-    width: 100%;
+    width: 90%;
+  }
+
+  .close_icon {
+    left: 85%;
   }
 }

--- a/src/components/compounds/Header/style.css
+++ b/src/components/compounds/Header/style.css
@@ -4,6 +4,7 @@
   justify-content: space-between;
   padding: 10px;
   font-family: 'Montserrat', sans-serif;
+  color: black;
 }
 
 @media screen and (max-width: 370px) {

--- a/src/pages/Landing/index.jsx
+++ b/src/pages/Landing/index.jsx
@@ -8,22 +8,27 @@ import Header from '../../components/compounds/Header';
 import Button from '../../components/atoms/Button';
 import AuthModalComponent from '../../components/compounds/AuthModal';
 
+import image from '../../static/images/landing.jpg';
+
 // Statics
 import style from './style.css';
 
 const Landing = (props) => {
   const { toggle } = props;
   return (
-    <div className={style.landing}>
-      <AuthModalComponent />
-      <Header />
-      <div className={style.hero}>
-        <h2>Harness the power in kindness</h2>
-        <p>We will help you get from where you are to where you need to be.</p>
+    <div className={style.wrapper}>
+      <img className={style.landing} src={image} alt="background" />
+      <div className={style.items}>
+        <AuthModalComponent />
+        <Header />
+        <div className={style.hero}>
+          <h2>Harness the power in kindness</h2>
+          <p>We will help you get from where you are to where you need to be.</p>
+        </div>
+        <Button className={style.btn} onClick={() => toggle(false)}>
+        FIND A RIDE
+        </Button>
       </div>
-      <Button className={style.btn} onClick={() => toggle(false)}>
-      FIND A RIDE
-      </Button>
     </div>
   );
 };

--- a/src/pages/Landing/style.css
+++ b/src/pages/Landing/style.css
@@ -1,12 +1,27 @@
+.wrapper {
+  height: 100vh;
+  background: rgba(54, 54, 54, 0.5);
+  color: white;
+}
+
 .landing {
-  background-image: url('../../static/images/landing.jpg');
+  width: 100%;
+  height: auto;
+  position: fixed;
+  z-index: -1;
+}
+
+.item {
+  position: relative;
+  height: 100%;
 }
 
 .hero {
   text-align: center;
-  width: fit-content;
-  margin: 15% auto 12% auto;
-  padding: 0 30px;
+  width: calc(100% - 20px);
+  min-height: 150px;
+  margin: 15% auto 5% auto;
+  padding: 40px 10px;
   font-family: 'Montserrat', sans-serif;
 }
 


### PR DESCRIPTION
### What does this PR do?
This PR fixes the landing page image responsiveness

### Tasks to be completed
> - Make landing page image responsive
> - Ensure text has a background to aid contrast

### How can this be manually tested
> - Clone the repo
> - Checkout the `ft-fix-image-responsiveness-#161617377` branch
> - Run `npm run dev`
> - View the landing page on a small device

### Screenshot
![image](https://user-images.githubusercontent.com/30635021/47787866-79f33f80-dd10-11e8-8510-b7e358196907.png)

### Relevant PT board stories
#161617377